### PR TITLE
feat: default to keeping user setting customizations around

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Dreamcast Controller Keys:
 |-------------------------|------------------------|
 | MinUI Menu Resume State | `X`                    |
 | Quit Game               | `MENU`                 |
+| Flycast Menu            | `SELECT`               |
 | Fast Forward            | `R2`                   |
 | Load State              | `L3`, or `HOTKEY 1`    |
 | Save State              | `R3`, or `HOTKEY 2`    |
@@ -60,6 +61,12 @@ Dreamcast Controller Keys:
 To change emulator settings, press and hold the `R2` button while selecting/resuming a game to play. Hold R2 until a menu appears.
 
 If the `B` or `MENU` buttons are pressed, the user is returned to the MinUI game selection screen. Settings are managed on a per-game basis, and can be saved for future gameplay, or the game can be started with the current settings as is.
+
+To start a game in this menu, press the `X` button. Any settings currently selected will be used for the game session.
+
+Settings in this menu can be saved by selecting `Save settings for game` and pressing the `A` button. This will save the settings and bring the user back to the menu. The `X` button can be pressed to start the game.
+
+This pak also ships with some default Flycast settings. Users may edit these settings in the in-emulator settings menu, and they will persist across game sessions. To reset these settings to the ones shipped with Flycast, select `Re-apply default flycast settings` and press the `A` button.
 
 #### Controller Layout
 

--- a/config.json
+++ b/config.json
@@ -36,6 +36,9 @@
         },
         {
             "name": "Save settings for game"
+        },
+        {
+            "name": "Re-apply default flycast settings"
         }
     ]
 }

--- a/launch.sh
+++ b/launch.sh
@@ -154,6 +154,17 @@ settings_menu() {
 				fi
 			}
 
+			selected_index="$(echo "$minui_list_output" | jq -r ' .selected')"
+			# 5 = Re-apply default emulator settings
+			if [ "$selected_index" -eq 5 ]; then
+				show_message "Re-applying default flycast settings" 2
+				mkdir -p "$FLYCAST_CONFIG_DIR"
+				cp -f "$PAK_DIR/config/emu.cfg" "${FLYCAST_CONFIG_DIR}emu.cfg"
+				sync
+				continue
+			fi
+
+			show_message "Saving settings for game" 2
 			# fetch values for next loop
 			controller_layout="$(echo "$minui_list_output" | jq -r --arg name "Controller Layout" '.settings[] | select(.name == $name) | .options[.selected]')"
 			cpu_mode="$(echo "$minui_list_output" | jq -r --arg name "CPU Mode" '.settings[] | select(.name == $name) | .options[.selected]')"
@@ -174,7 +185,9 @@ settings_menu() {
 configure_platform() {
 	# ensure config and data directories and files exist
 	mkdir -p "$FLYCAST_CONFIG_DIR" "$FLYCAST_DATA_DIR"
-	cp -f "$PAK_DIR/config/emu.cfg" "${FLYCAST_CONFIG_DIR}emu.cfg"
+	if [ ! -f "${FLYCAST_CONFIG_DIR}emu.cfg" ]; then
+		cp -f "$PAK_DIR/config/emu.cfg" "${FLYCAST_CONFIG_DIR}emu.cfg"
+	fi
 
 	# migrate non-bios files are moved to the $FLYCAST_DATA_DIR
 	cd "$FLYCAST_BIOS_DIR"


### PR DESCRIPTION
Instead of always overriding settings, only reset them when the user elects to do so.

Closes #5